### PR TITLE
Adapt to sxyazi/yazi#1761 and sxyazi/yazi#1776

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M:peek()
 	local child
-	local l = self.file.cha.length
+	local l = self.file.cha.len
 	if l == 0 then
 		child = Command("hexyl")
 			:args({
@@ -43,13 +43,10 @@ function M:peek()
 
 	child:start_kill()
 	if self.skip > 0 and i < self.skip + limit then
-		ya.manager_emit(
-			"peek",
-			{ tostring(math.max(0, i - limit)), only_if = tostring(self.file.url), upper_bound = "" }
-		)
+		ya.manager_emit("peek", { math.max(0, i - limit), only_if = self.file.url, upper_bound = true })
 	else
 		lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
-		ya.preview_widgets(self, { ui.Paragraph.parse(self.area, lines) })
+		ya.preview_widgets(self, { ui.Text.parse(lines):area(self.area) })
 	end
 end
 


### PR DESCRIPTION
There were some changes in upstream Yazi that break the plugin, namely sxyazi/yazi#1761 and sxyazi/yazi#1776.

This PR fixes it, however it might be better to wait for v0.4, I'm not sure if this break the plugin in v0.3.3