### PR TITLE
fix(self): sxyazi/yazi#1966 🐛 Switched to `job` from `self` (deprecated)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M:peek(job)
 	local child
-	local l = self.file.cha.len
+	local l = job.file.cha.len
 	if l == 0 then
 		child = Command("hexyl")
 			:args({


### PR DESCRIPTION
DEPRECATED: `self` sxyazi/yazi#1966 (by @sxyazi)
Closes: #8 