### PR TITLE
Update API deprecated in yazi v25.2.26

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -46,13 +46,13 @@ function M:peek(job)
 
   child:start_kill()
   if job.skip > 0 and i < job.skip + limit then
-    ya.manager_emit("peek", {
+    ya.mgr_emit("peek", {
       math.max(0, i - limit),
       only_if = job.file.url,
       upper_bound = true,
     })
   else
-    lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
+    lines = lines:gsub("\t", string.rep(" ", rt.preview.tab_size))
     ya.preview_widgets(job, { ui.Text.parse(lines):area(job.area) })
   end
 end
@@ -67,7 +67,7 @@ function M:seek(job)
   local scroll_offset = job.units
 
   -- Emit a new peek event with the updated skip value.
-  ya.manager_emit("peek", {
+  ya.mgr_emit("peek", {
     math.max(0, cx.active.preview.skip + scroll_offset),
     only_if = job.file.url,
   })


### PR DESCRIPTION
From yazi [release note](https://github.com/sxyazi/yazi/releases/tag/v25.2.26):
- MANAGER, PREVIEW, PLUGIN, and THEME have been deprecated in favor of the new rt and th.
  sxyazi/yazi#2389
- ya.manager_emit() has been deprecated in favor of the new ya.mgr_emit().
  sxyazi/yazi#2397

This PR fixed the preview not showing in the latest yazi release.