### PR TITLE
fix: update for deprecated api yazi v25.5.28

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -5,7 +5,7 @@ function M:peek(job)
   local l = job.file.cha.len
   if l == 0 then
     child = Command("hexyl")
-        :args({
+        :arg({
           tostring(job.file.url),
         })
         :stdout(Command.PIPED)
@@ -13,7 +13,7 @@ function M:peek(job)
         :spawn()
   else
     child = Command("hexyl")
-        :args({
+        :arg({
           "--border", "none",
           "--terminal-width", tostring(job.area.w),
           tostring(job.file.url),


### PR DESCRIPTION
Since yazi v25.5.28 [release notes](https://github.com/sxyazi/yazi/releases/v25.5.28):
	- Command:args() is deprecated in favor of Command:arg() as mentioned in: sxyazi/yazi#2752