### PR TITLE
"Deprecated API"  Fix

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -5,7 +5,7 @@ function M:peek(job)
   local l = job.file.cha.len
   if l == 0 then
     child = Command("hexyl")
-        :args({
+        :arg({
           tostring(job.file.url),
         })
         :stdout(Command.PIPED)
@@ -13,7 +13,7 @@ function M:peek(job)
         :spawn()
   else
     child = Command("hexyl")
-        :args({
+        :arg({
           "--border", "none",
           "--terminal-width", tostring(job.area.w),
           tostring(job.file.url),


### PR DESCRIPTION
⚠️ Deprecated API
The `args()` method on `Command` is deprecated, use `arg()` instead in your 'hexyl.yazi' plugin See #2752 for more details: https://github.com/sxyazi/yazi/pull/2752